### PR TITLE
Solution to PDF_Accessibility Issue #40: Failing to create GUI 

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,18 +17,28 @@ phases:
       - echo "Building TypeScript sources"
       - npm run build
       - echo "Bootstrapping CDK (no approval)..."
-      - >-
-        cdk bootstrap --require-approval never \
-          -c PDF_TO_PDF_BUCKET=$PDF_TO_PDF_BUCKET \
-          -c PDF_TO_HTML_BUCKET=$PDF_TO_HTML_BUCKET
+      - |
+        CDK_CONTEXT=""
+        if [ -n "${PDF_TO_PDF_BUCKET:-}" ]; then
+          CDK_CONTEXT="$CDK_CONTEXT -c PDF_TO_PDF_BUCKET=$PDF_TO_PDF_BUCKET"
+        fi
+        if [ -n "${PDF_TO_HTML_BUCKET:-}" ]; then
+          CDK_CONTEXT="$CDK_CONTEXT -c PDF_TO_HTML_BUCKET=$PDF_TO_HTML_BUCKET"
+        fi
+        cdk deploy --all --require-approval never $CDK_CONTEXT
 
   build:
     commands:
       - echo "Deploying all CDK stacks..."
-      - >-
-        cdk deploy --all --require-approval never \
-          -c PDF_TO_PDF_BUCKET=$PDF_TO_PDF_BUCKET \
-          -c PDF_TO_HTML_BUCKET=$PDF_TO_HTML_BUCKET
+      - |
+        CDK_CONTEXT=""
+        if [ -n "${PDF_TO_PDF_BUCKET:-}" ]; then
+          CDK_CONTEXT="$CDK_CONTEXT -c PDF_TO_PDF_BUCKET=$PDF_TO_PDF_BUCKET"
+        fi
+        if [ -n "${PDF_TO_HTML_BUCKET:-}" ]; then
+          CDK_CONTEXT="$CDK_CONTEXT -c PDF_TO_HTML_BUCKET=$PDF_TO_HTML_BUCKET"
+        fi
+        cdk deploy --all --require-approval never $CDK_CONTEXT
 
   post_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -25,7 +25,7 @@ phases:
         if [ -n "${PDF_TO_HTML_BUCKET:-}" ] && [ "${PDF_TO_HTML_BUCKET}" != "Null" ]; then
           CDK_CONTEXT="$CDK_CONTEXT -c PDF_TO_HTML_BUCKET=$PDF_TO_HTML_BUCKET"
         fi
-        cdk deploy --all --require-approval never $CDK_CONTEXT
+        cdk bootstrap --require-approval never $CDK_CONTEXT
 
 
   build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,26 +19,28 @@ phases:
       - echo "Bootstrapping CDK (no approval)..."
       - |
         CDK_CONTEXT=""
-        if [ -n "${PDF_TO_PDF_BUCKET:-}" ]; then
+        if [ -n "${PDF_TO_PDF_BUCKET:-}" ] && [ "${PDF_TO_PDF_BUCKET}" != "Null" ]; then
           CDK_CONTEXT="$CDK_CONTEXT -c PDF_TO_PDF_BUCKET=$PDF_TO_PDF_BUCKET"
         fi
-        if [ -n "${PDF_TO_HTML_BUCKET:-}" ]; then
+        if [ -n "${PDF_TO_HTML_BUCKET:-}" ] && [ "${PDF_TO_HTML_BUCKET}" != "Null" ]; then
           CDK_CONTEXT="$CDK_CONTEXT -c PDF_TO_HTML_BUCKET=$PDF_TO_HTML_BUCKET"
         fi
         cdk deploy --all --require-approval never $CDK_CONTEXT
+
 
   build:
     commands:
       - echo "Deploying all CDK stacks..."
       - |
         CDK_CONTEXT=""
-        if [ -n "${PDF_TO_PDF_BUCKET:-}" ]; then
+        if [ -n "${PDF_TO_PDF_BUCKET:-}" ] && [ "${PDF_TO_PDF_BUCKET}" != "Null" ]; then
           CDK_CONTEXT="$CDK_CONTEXT -c PDF_TO_PDF_BUCKET=$PDF_TO_PDF_BUCKET"
         fi
-        if [ -n "${PDF_TO_HTML_BUCKET:-}" ]; then
+        if [ -n "${PDF_TO_HTML_BUCKET:-}" ] && [ "${PDF_TO_HTML_BUCKET}" != "Null" ]; then
           CDK_CONTEXT="$CDK_CONTEXT -c PDF_TO_HTML_BUCKET=$PDF_TO_HTML_BUCKET"
         fi
         cdk deploy --all --require-approval never $CDK_CONTEXT
+
 
   post_build:
     commands:

--- a/cdk_backend/lib/cdk_backend-stack.ts
+++ b/cdk_backend/lib/cdk_backend-stack.ts
@@ -82,7 +82,7 @@ export class CdkBackendStack extends cdk.Stack {
       status: amplify.RedirectStatus.REWRITE
     }));
 
-    const domainPrefix = `pdf-ui-auth-${cdk.Names.uniqueId(this).slice(-8).toLowerCase()}`; // must be globally unique in that region
+    const domainPrefix = `pdf-ui-auth-${this.account}-${this.region}`; // must be globally unique in that region
     const Default_Group = 'DefaultUsers';
     const Amazon_Group = 'AmazonUsers';
     const Admin_Group = 'AdminUsers';

--- a/cdk_backend/lib/cdk_backend-stack.ts
+++ b/cdk_backend/lib/cdk_backend-stack.ts
@@ -272,8 +272,7 @@ export class CdkBackendStack extends cdk.Stack {
     // Domain prefix is defined above with appUrl
     const userPoolDomain = new cognito.CfnUserPoolDomain(this, 'PDF-Accessability-User-Pool-Domain', {
       domain: domainPrefix,
-      userPoolId: userPool.userPoolId,
-      managedLoginVersion: 2,
+      userPoolId: userPool.userPoolId
     });
 
     const userPoolClient = userPool.addClient('PDF-Accessability-User-Pool-Client', {
@@ -306,14 +305,6 @@ export class CdkBackendStack extends cdk.Stack {
 
     
 
-    // (Optional) If CfnManagedLoginBranding is not critical, remove it or put it in a separate stack
-    const managed_login = new cognito.CfnManagedLoginBranding(this, 'MyManagedLoginBranding', {
-      userPoolId: userPool.userPoolId,
-      clientId: userPoolClient.userPoolClientId,
-      returnMergedResources: true,
-      useCognitoProvidedValues: true,
-      
-    });
 
     // ------------- Identity Pool + IAM Roles for S3 Access --------------------
     const identityPool = new cognito.CfnIdentityPool(this, 'PDFIdentityPool', {

--- a/cdk_backend/lib/cdk_backend-stack.ts
+++ b/cdk_backend/lib/cdk_backend-stack.ts
@@ -82,7 +82,7 @@ export class CdkBackendStack extends cdk.Stack {
       status: amplify.RedirectStatus.REWRITE
     }));
 
-    const domainPrefix = `pdf-ui-auth${Math.random().toString(36).substring(2, 8)}`; // must be globally unique in that region
+    const domainPrefix = `pdf-ui-auth-${cdk.Names.uniqueId(this).slice(-8).toLowerCase()}`; // must be globally unique in that region
     const Default_Group = 'DefaultUsers';
     const Amazon_Group = 'AmazonUsers';
     const Admin_Group = 'AdminUsers';
@@ -272,7 +272,8 @@ export class CdkBackendStack extends cdk.Stack {
     // Domain prefix is defined above with appUrl
     const userPoolDomain = new cognito.CfnUserPoolDomain(this, 'PDF-Accessability-User-Pool-Domain', {
       domain: domainPrefix,
-      userPoolId: userPool.userPoolId
+      userPoolId: userPool.userPoolId,
+      managedLoginVersion: 2,
     });
 
     const userPoolClient = userPool.addClient('PDF-Accessability-User-Pool-Client', {
@@ -305,6 +306,14 @@ export class CdkBackendStack extends cdk.Stack {
 
     
 
+    // (Optional) If CfnManagedLoginBranding is not critical, remove it or put it in a separate stack
+    const managed_login = new cognito.CfnManagedLoginBranding(this, 'MyManagedLoginBranding', {
+      userPoolId: userPool.userPoolId,
+      clientId: userPoolClient.userPoolClientId,
+      returnMergedResources: true,
+      useCognitoProvidedValues: true,
+      
+    });
 
     // ------------- Identity Pool + IAM Roles for S3 Access --------------------
     const identityPool = new cognito.CfnIdentityPool(this, 'PDFIdentityPool', {

--- a/cdk_backend/lib/cdk_backend-stack.ts
+++ b/cdk_backend/lib/cdk_backend-stack.ts
@@ -17,8 +17,8 @@ export class CdkBackendStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
     
-    const PDF_TO_PDF_BUCKET = this.node.tryGetContext('PDF_TO_PDF_BUCKET') || "Null";
-    const PDF_TO_HTML_BUCKET = this.node.tryGetContext('PDF_TO_HTML_BUCKET') || "Null";
+    const PDF_TO_PDF_BUCKET = this.node.tryGetContext('PDF_TO_PDF_BUCKET');
+    const PDF_TO_HTML_BUCKET = this.node.tryGetContext('PDF_TO_HTML_BUCKET');
 
     // Validate that at least one bucket is provided
     if (!PDF_TO_PDF_BUCKET && !PDF_TO_HTML_BUCKET) {

--- a/deploy.sh
+++ b/deploy.sh
@@ -448,7 +448,7 @@ BACKEND_ENVIRONMENT="$BACKEND_ENVIRONMENT"'}'
 # Backend buildspec
 BACKEND_SOURCE='{
   "type":"GITHUB",
-  "location":"https://github.com/ASUCICREPO/PDF_accessability_UI.git",
+  "location":"https://github.com/ShawnN24/PDF_accessability_UI.git",
   "buildspec":"buildspec.yml"
 }'
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -448,7 +448,7 @@ BACKEND_ENVIRONMENT="$BACKEND_ENVIRONMENT"'}'
 # Backend buildspec
 BACKEND_SOURCE='{
   "type":"GITHUB",
-  "location":"https://github.com/ShawnN24/PDF_accessability_UI.git",
+  "location":"https://github.com/ASUCICREPO/PDF_accessability_UI.git",
   "buildspec":"buildspec.yml"
 }'
 


### PR DESCRIPTION
[PDF_Accessibility Issue #40](https://github.com/ASUCICREPO/PDF_Accessibility/issues/40)

Solution: Fixed UI deployments using one bucket

Changes:
cdk_backend-stack.ts
Line 34 and 39 respectively checks to see if PDF_TO_PDF_BUCKET and PDF_TO_HTML_BUCKET exist.
- I updated line 20 & 21 to remove or "Null" because a string of Null still counts as an existing value.
- This caused an issue where if either bucket was not deployed. An error would be thrown stating the missing bucket does not exist preventing the UI from deploying

Line 85 was updated to be deterministic instead of relying on Math.random for a unique name.
- The deployment would fail because the initial deployment would be mismatched with the updated deployment.
- This is because the initial deployment would create fine but need to be updated because of the amplify app id which isn't known until the amplify app is created. This would result in the deployment failing because the domainPrefix's didn't match.

buildspec.yml
Updated to check for bucket existence before deploying