### PR TITLE
presignup lambda fix for auth issues

### DIFF
--- a/cdk_backend/lambda/preSignUp/index.py
+++ b/cdk_backend/lambda/preSignUp/index.py
@@ -1,0 +1,27 @@
+import boto3
+import os
+
+client = boto3.client('cognito-idp')
+
+def handler(event, context):
+    user_pool_id = event['userPoolId']
+    email = event['request']['userAttributes'].get('email')
+
+    if not email:
+        return event
+
+    # Check if an UNCONFIRMED user with this email already exists
+    response = client.list_users(
+        UserPoolId=user_pool_id,
+        Filter=f'email = "{email}"',
+    )
+
+    for user in response.get('Users', []):
+        if user['UserStatus'] == 'UNCONFIRMED':
+            client.admin_delete_user(
+                UserPoolId=user_pool_id,
+                Username=user['Username'],
+            )
+            print(f"Deleted UNCONFIRMED user: {user['Username']}")
+
+    return event

--- a/cdk_backend/lambda/preSignUp/index.py
+++ b/cdk_backend/lambda/preSignUp/index.py
@@ -1,27 +1,29 @@
 import boto3
-import os
-
-client = boto3.client('cognito-idp')
 
 def handler(event, context):
-    user_pool_id = event['userPoolId']
-    email = event['request']['userAttributes'].get('email')
+    try:
+        client = boto3.client('cognito-idp')
+        user_pool_id = event['userPoolId']
+        email = event['request']['userAttributes'].get('email')
 
-    if not email:
-        return event
+        if not email:
+            return event
 
-    # Check if an UNCONFIRMED user with this email already exists
-    response = client.list_users(
-        UserPoolId=user_pool_id,
-        Filter=f'email = "{email}"',
-    )
+        # Check if an UNCONFIRMED user with this email already exists
+        response = client.list_users(
+            UserPoolId=user_pool_id,
+            Filter=f'email = "{email}"',
+        )
 
-    for user in response.get('Users', []):
-        if user['UserStatus'] == 'UNCONFIRMED':
-            client.admin_delete_user(
-                UserPoolId=user_pool_id,
-                Username=user['Username'],
-            )
-            print(f"Deleted UNCONFIRMED user: {user['Username']}")
+        for user in response.get('Users', []):
+            if user['UserStatus'] == 'UNCONFIRMED':
+                client.admin_delete_user(
+                    UserPoolId=user_pool_id,
+                    Username=user['Username'],
+                )
+                print(f"Deleted UNCONFIRMED user: {user['Username']}")
+    
+    except Exception as error:
+        print(f'Error in pre-signup trigger: {error}')
 
     return event

--- a/cdk_backend/lib/cdk_backend-stack.ts
+++ b/cdk_backend/lib/cdk_backend-stack.ts
@@ -194,6 +194,11 @@ export class CdkBackendStack extends cdk.Stack {
       signInAliases: { email: true },
 
       autoVerify: { email: true },
+      userVerification: {
+        emailStyle: cognito.VerificationEmailStyle.LINK,
+        emailSubject: 'Verify your email for PDF Accessibility',
+        emailBody: 'Please click the link below to verify your email address: {##Verify Email##}',
+      },
       passwordPolicy: {
         minLength: 8,
         requireLowercase: true,
@@ -542,6 +547,43 @@ export class CdkBackendStack extends cdk.Stack {
     updateAttributesGroupsFn.addPermission('AllowEventBridgeInvoke', {
       principal: new iam.ServicePrincipal('events.amazonaws.com'),
       sourceArn: cognitoGroupChangeRule.ruleArn,
+    });
+
+    const preSignUpRole = new iam.Role(this, 'PreSignUpRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      description: 'IAM role for PreSignUp Lambda function',
+    });
+
+    preSignUpRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole')
+    );
+
+    const preSignUpFn = new lambda.Function(this, 'PreSignUpLambda', {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset('lambda/preSignUp/'),
+      timeout: cdk.Duration.seconds(30),
+      role: preSignUpRole,
+    });
+
+    // Attach the preSignUp trigger to the user pool
+    userPool.addTrigger(cognito.UserPoolOperation.PRE_SIGN_UP, preSignUpFn);
+
+    // Scoped Cognito policy for listing and deleting UNCONFIRMED users
+    new iam.CfnPolicy(this, 'PreSignUpCognitoPolicy', {
+      policyName: 'PreSignUpCognitoAccess',
+      policyDocument: {
+        Version: '2012-10-17',
+        Statement: [{
+          Effect: 'Allow',
+          Action: [
+            'cognito-idp:ListUsers',
+            'cognito-idp:AdminDeleteUser',
+          ],
+          Resource: userPool.userPoolArn,
+        }],
+      },
+      roles: [preSignUpRole.roleName],
     });
     
     // --------------------------- Outputs ------------------------------


### PR DESCRIPTION
- Added PreSignUp lambda to handle unconfirmed users who are trying to signup again.

- Changed email verification to link based as opposed to confirmation code based.