### PR TITLE
Fix landing page popup upload limit copy (3 → 8)

### DIFF
--- a/pdf_ui/src/pages/LandingPage.jsx
+++ b/pdf_ui/src/pages/LandingPage.jsx
@@ -510,7 +510,7 @@ const LandingPage = () => {
       <strong>Please note the following restrictions before uploading:</strong>
     </Typography>
     <Typography variant="body2" component="p" paragraph>
-      1. Each user is limited to <strong>3</strong> PDF document uploads.
+      1. Each user is limited to <strong>8</strong> PDF document uploads.
     </Typography>
     <Typography variant="body2" component="p" paragraph>
       2. Documents cannot exceed <strong>10</strong> pages.


### PR DESCRIPTION
## What
Updates the landing page restrictions popup in `LandingPage.jsx` from "limited to **3** PDF document uploads" to **8**, matching the real per-user default (already shown in the logged-in sidebar, `LeftNav.jsx`).

## Why
The popup copy was stale. It is **display text only** — it has no connection to quota enforcement. The actual limit is stored per-user in the Cognito attribute `custom:max_files_allowed` (read in `MainApp.js`, enforced in `UploadSection.jsx` and the `checkOrIncrementQuota` Lambda). This change does **not** grant or alter anyone's upload quota.

## Scope
- 1 file, 1 line, text only. No logic, no functional change.

## Note (separate follow-up, not in this PR)
Some existing users still have a stored limit of 3/5 from a historical deploy issue (Jan–Feb 2026) that has since been corrected. Fixing those users is a Cognito data update, tracked separately — **no code change required**.